### PR TITLE
Raise package minimum target to iOS 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "PSActivityImageViewController",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v11)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
.... in order to address strange XCode 13 bug with package min. iOS v10.

Fixes #3 